### PR TITLE
Added a Log Level to Keep the Logger Quiet

### DIFF
--- a/lib/nodecr.js
+++ b/lib/nodecr.js
@@ -5,6 +5,7 @@ var exec    = require('child_process').exec,
 /**
 * Attention: Tesseract 3.01 or higher is needed for this to work
 */
+
 var tesseract = {
 
   /**
@@ -12,6 +13,7 @@ var tesseract = {
   * @param image        Can be any format that your installed Leptonica library can process
   *                     (additional libraries might be required by Leptonica)
   *
+  * @param logLevel     (Optional) The log level. If zero, then no logging (zero by default)
   * @param callback     A function pointer
   *                     this function is called after the recognition has taken place
   *                     with a possible error as first and the resulting recognized text as second parameter
@@ -39,8 +41,11 @@ var tesseract = {
   *
   * @param config       (Optional) A config file name
   */
-  process: function process(image, callback, languageCode, pageSegMode, config, preprocessor) {
-    (preprocessor || tesseract.preprocessor)(image, function(err, processedImage, cleanup) {
+  process: function process(image, logLevel, callback, languageCode, pageSegMode, config, preprocessor){
+    tesseract.logLevel = logLevel || tesseract.logLevel
+    ; // required because of below...
+    
+    (preprocessor || tesseract.preprocessor)(image, function(err, processedImage, cleanup){
       if(err) {
         // error in preprocessor
         callback(err, null);
@@ -48,7 +53,7 @@ var tesseract = {
       }
       tesseract._runTesseract(processedImage, function(err, text) {
         if(typeof cleanup == 'function') {
-          console.log("node-tesseract: Preprocessor cleanup");
+          if(logLevel) console.log("node-tesseract: Preprocessor cleanup");
           cleanup();
         }
         callback(err, text);
@@ -57,6 +62,9 @@ var tesseract = {
   },
 
   _runTesseract: function(image, callback, languageCode, pageSegMode, config) {
+    
+    tesseract.logLevel
+    
     // generate output file name
     tmp.tmpName(function(err, output) {
       if(err) {
@@ -83,7 +91,7 @@ var tesseract = {
       command = command.join(' ');
 
       // Run the tesseract command
-      console.log("node-tesseract: Running '" + command + "'");
+      if(tesseract.logLevel) console.log("node-tesseract: Running '" + command + "'");
       exec(command, function(err, stdout, stderr){
         if(err) {
           // Something went wrong executing the assembled command
@@ -97,7 +105,7 @@ var tesseract = {
             // There was no error, so get the text
             data = data.toString(tesseract.outputEncoding);
           }
-          console.log("node-tesseract: Deleting '"+outputFile+"'");
+          if(tesseract.logLevel) console.log("node-tesseract: Deleting '"+outputFile+"'");
           fs.unlink(outputFile, function (err) {
             // ignore any errors here as it just means we have a temporary file left somewehere
           });
@@ -128,13 +136,14 @@ var tesseract = {
     callback(error,outputFile,cleanup);
   },
   binary: 'tesseract',
-  outputEncoding: 'UTF-8'
+  outputEncoding: 'UTF-8',
+  logLevel: 0
 }
 
 // OTB preprocessors
 
-var ConvertPreprocessor = function(inputFile, callback) {
-  console.log("node-tesseract: preprocessor: convert: Processing '"+inputFile+"'");
+var ConvertPreprocessor = function(inputFile, callback, logLevel){
+  if(tesseract.logLevel) console.log("node-tesseract: preprocessor: convert: Processing '"+inputFile+"'");
   tmp.tmpName({postfix: '.tif'}, function(err, outputFile) {
     if(err) {
       // Something went wrong when generating the temporary filename
@@ -143,14 +152,14 @@ var ConvertPreprocessor = function(inputFile, callback) {
     }
   
     var command = ['convert', '-type','Grayscale', '-resize','200%', '-sharpen','10', inputFile, outputFile].join(' ');
-    console.log("node-tesseract: preprocessor: convert: Running '"+command+"'");
+    if(tesseract.logLevel) console.log("node-tesseract: preprocessor: convert: Running '"+command+"'");
     exec(command, function(err, stdout, stderr){
       if(err) {
         // Something went wrong executing the convert command
         callback(err, null);
       } else {
         var cleanup = function() {
-          console.log("node-tesseract: preprocessor: convert: Deleting '"+outputFile+"'");
+          if(tesseract.logLevel) console.log("node-tesseract: preprocessor: convert: Deleting '"+outputFile+"'");
           fs.unlink(outputFile, function (err) {
             // ignore any errors here as it just means we have a temporary file left somewehere
           });
@@ -163,6 +172,7 @@ var ConvertPreprocessor = function(inputFile, callback) {
 
 // Exports
 
+module.exports.logOutput = tesseract.logOutput;
 module.exports.process = tesseract.process;
 module.exports.preprocessors = {
   convert: ConvertPreprocessor


### PR DESCRIPTION
Added a property to the Tesseract object and just a quick fix to keep the logger quiet.  The `process` method's signature has changed to pass in the log level as the 2nd argument.
